### PR TITLE
Исправлен баг с длинными значениями полей

### DIFF
--- a/backend/garpix_utils/cef_logs/event/base.py
+++ b/backend/garpix_utils/cef_logs/event/base.py
@@ -52,6 +52,9 @@ class BaseEvent(Event, abc.ABC):
     suser = None
 
     def __call__(self, **fields):
+
+        fields = truncate_dict_by_model(fields)
+
         user = fields.pop("user", None)
         request = fields.pop("request", None)
         if "fname" in fields:


### PR DESCRIPTION
Добавлена проверка длины расширенных полей для который указано ограничение в исходной библиотеке.
Если поле больше допустимого, оно обрезается до максимальной длины